### PR TITLE
Marked as GS 3.16 compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,9 @@
-{"shell-version": ["3.14.4"], "uuid": "keyboard_modifiers_status@sneetsher", "name": "Keyboard Modifiers Status", "description": "Shows keyboard modifiers status. It's much useful when sticky keys are active."}
+{
+	"shell-version": [
+		"3.14",
+		"3.16"
+	],
+	"uuid": "keyboard_modifiers_status@sneetsher",
+	"name": "Keyboard Modifiers Status",
+	"description": "Shows keyboard modifiers status. It's much useful when sticky keys are active."
+}


### PR DESCRIPTION
Tested and marked as compatible with Gnome Shell 3.16. I think it is not a good idea to insert a version like "3.14.4" for it should be compatible with all 3.14 versions if it is with one of them.
