### PR TITLE
Configurable symbols for modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 package/
+schemas/gschemas.compiled

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,7 +6,7 @@ This is a very small and simple extension. It can be easily modified or used as 
 ## Debug tools
 
 - LookingGlass tool.
-- Follow system log, using `make debug`
+- Follow system log, using `make debug` (extension prints Shell and Clutter versions on startup)
 
 
 ## Package

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build:
 install:
 	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
 	cp ./*.js* ./*.css ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
+	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	cp schemas/*.gschema.xml ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	glib-compile-schemas ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
 
 test: test-js
 
@@ -25,7 +28,10 @@ dist-clean:
 
 dist: dist-clean
 	mkdir -p package
-	zip -j package/keyboard_modifiers_status@sneetsher.zip ./*.js* ./*.css
+	glib-compile-schemas schemas
+	zip -j package/keyboard_modifiers_status@sneetsher.zip \
+./*.js* ./*.css schemas/*.gschema.xml schemas/gschemas.compiled
+	rm schemas/gschemas.compiled
 
 test-js:
 	gjs ./lab/test_gjs_gdk_modifiers.js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Choose a method
             unzip keyboard_modifiers_status@sneetsher.zip -d ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher
 
         or
-            
+
             make install
     
     2. Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd> with Xorg or logout/login with Wayland.
@@ -33,6 +33,9 @@ Choose a method
 
 
 ## Extras
+
+- The preferences window allows customizing modifier mappings and display symbols.
+  Symbols can be adjusted individually, loaded from presets or saved as a custom preset.
 
 - Enable an extension for all users (machine-wide)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 New features to do:
 
 - Add modifiers latch and lock for Xorg.
-- Add debuging to check API version.
 
 - Make indicator as for system (Shows also in login & lock screen)
   Won't fix as Gnome drop the option, So only with Gnome modification.

--- a/extension.js
+++ b/extension.js
@@ -31,7 +31,19 @@ const dbg = false;
 
 //TODO: convert into preferrence.
 const tag = "KMS-Ext:";
-const mod_sym = "⇧⇬⋀⌥①◆⌘⎇";
+
+// Mapping of modifier masks to the displayed symbol
+const MODIFIERS = [
+    [Clutter.ModifierType.SHIFT_MASK, '⇧'],
+    [Clutter.ModifierType.LOCK_MASK, '⇬'],
+    [Clutter.ModifierType.CONTROL_MASK, '⋀'],
+    [Clutter.ModifierType.MOD1_MASK, '⌥'],
+    [Clutter.ModifierType.MOD2_MASK, '①'],
+    [Clutter.ModifierType.MOD3_MASK, '◆'],
+    [Clutter.ModifierType.MOD4_MASK, '⌘'],
+    [Clutter.ModifierType.MOD5_MASK, '⎇'],
+];
+
 const latch_sym = "'";
 const lock_sym = "◦";
 const icon = ""; //"⌨ ";
@@ -167,24 +179,14 @@ export default class KMS extends Extension {
         if ((this.state != this.prev_state) || this.latch != this.prev_latch || this.lock != this.prev_lock) {
             console.debug(`${tag} State changed... ${this.prev_state}, ${this.state}`);
             this.indicator = icon + opening + " ";
-            //TODO: don't relay on internal order
-            //      use standard pre-defined constant masks
-            for (var i=0; i<8; i++ ) {
-                if ((this.state & 1<<i) || (this.lock & 1<<i)) {
-                    this.indicator += mod_sym[i];
-                } else {
-                    //indicator += "";
-                };
-                if (this.latch & 1<<i) {
-                    this.indicator += latch_sym + " ";
-                } else {
-                    //indicator += "";
-                };
-                if (this.lock & 1<<i) {
-                    this.indicator += lock_sym + " ";
-                } else {
-                    //indicator += "";
-                };
+            // Iterate using the predefined modifier masks
+            for (const [mask, sym] of MODIFIERS) {
+                if ((this.state & mask) || (this.lock & mask))
+                    this.indicator += sym;
+                if (this.latch & mask)
+                    this.indicator += latch_sym + ' ';
+                if (this.lock & mask)
+                    this.indicator += lock_sym + ' ';
             }
             this.indicator += " " + closing;
 

--- a/extension.js
+++ b/extension.js
@@ -38,27 +38,27 @@ const icon = ""; //"⌨ ";
 const opening = ""; //"_";
 const closing = ""; //"_";
 
-//TODO: eliminate global variables
-let seat;
-let button,
-    label;
-
-let state,
-    prev_state,
-    latch,
-    prev_latch,
-    lock,
-    prev_lock;
-
-let indicator;
-
-let timeout_id,
-    mods_update_id;
 
 // Gnome-shell extension interface
 // init, enable, disable
 
 export default class KMS extends Extension {
+
+    seat = null;
+    button = null;
+    label = null;
+
+    state = 0;
+    prev_state = 0;
+    latch = 0;
+    prev_latch = 0;
+    lock = 0;
+    prev_lock = 0;
+
+    indicator = null;
+
+    timeout_id = null;
+    mods_update_id = null;
 
 
     constructor(metadata) {
@@ -70,46 +70,47 @@ export default class KMS extends Extension {
     enable() {
         console.debug(`${tag} enable() ... in`);
 
-        //
+        // Initialize properties
+        this.seat = null;
+        this.button = null;
+        this.label = null;
 
-        seat = null;
-        button = null;
-        label = null;
+        this.state = 0;
+        this.prev_state = 0;
+        this.latch = 0;
+        this.prev_latch = 0;
+        this.lock = 0;
+        this.prev_lock = 0;
 
-        state = 0;
-        prev_state = 0;
-        latch = 0;
-        prev_latch = 0;
-        lock = 0;
-        prev_lock = 0;
+        this.indicator = null;
 
-        timeout_id = null;
-        mods_update_id = null;
+        this.timeout_id = null;
+        this.mods_update_id = null;
 
-        //
-        button = new St.Bin({ style_class: 'panel-button',
+        // Create UI elements
+        this.button = new St.Bin({ style_class: 'panel-button',
             reactive: false,
             can_focus: false,
             x_expand: true,
             y_expand: false,
             track_hover: false });
-        label = new St.Label({ style_class: "state-label", text: "" });
-        button.set_child(label);
+        this.label = new St.Label({ style_class: "state-label", text: "" });
+        this.button.set_child(this.label);
 
         //console.debug(`${tag} Running Wayland: ` + Meta.is_wayland_compositor());
 
         try {
-            seat = Clutter.get_default_backend().get_default_seat();
+            this.seat = Clutter.get_default_backend().get_default_seat();
         } catch (e) {
-            seat = Clutter.DeviceManager.get_default();
+            this.seat = Clutter.DeviceManager.get_default();
         };
 
-        if (seat) {
-            mods_update_id = seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update);
+        if (this.seat) {
+            this.mods_update_id = this.seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update.bind(this));
         };
 
-        Main.panel._rightBox.insert_child_at_index(button, 0);
-        timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update);
+        Main.panel._rightBox.insert_child_at_index(this.button, 0);
+        this.timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update.bind(this));
 
         console.debug(`${tag} enable() ... out`);
     }
@@ -118,23 +119,32 @@ export default class KMS extends Extension {
     disable() {
         console.debug(`${tag} disable() ... in`);
 
-        Main.panel._rightBox.remove_child(button);
+        Main.panel._rightBox.remove_child(this.button);
 
-        GLib.source_remove(timeout_id);
+        GLib.source_remove(this.timeout_id);
 
-        if (seat && mods_update_id) {
-            seat.disconnect(mods_update_id);
+        if (this.seat && this.mods_update_id) {
+            this.seat.disconnect(this.mods_update_id);
         };
 
-        button.destroy_all_children();
-        button.destroy();
+        this.button.destroy_all_children();
+        this.button.destroy();
 
-        seat = null;
-        button = null;
-        label = null;
+        this.seat = null;
+        this.button = null;
+        this.label = null;
 
-        timeout_id = null;
-        mods_update_id = null;
+        this.state = 0;
+        this.prev_state = 0;
+        this.latch = 0;
+        this.prev_latch = 0;
+        this.lock = 0;
+        this.prev_lock = 0;
+
+        this.indicator = null;
+
+        this.timeout_id = null;
+        this.mods_update_id = null;
 
         console.debug(`${tag} disable() ... out`);
     }
@@ -149,40 +159,40 @@ export default class KMS extends Extension {
         // is the effective
 
         const [x, y, m] = global.get_pointer();
-        
+
         if (typeof m !== 'undefined') {
-            state = m;
+            this.state = m;
         };
 
-        if ((state != prev_state) || latch != prev_latch || lock != prev_lock) {
-            console.debug(`${tag} State changed... ${prev_state}, ${state}`);
-            indicator = icon + opening + " ";
+        if ((this.state != this.prev_state) || this.latch != this.prev_latch || this.lock != this.prev_lock) {
+            console.debug(`${tag} State changed... ${this.prev_state}, ${this.state}`);
+            this.indicator = icon + opening + " ";
             //TODO: don't relay on internal order
             //      use standard pre-defined constant masks
             for (var i=0; i<8; i++ ) {
-                if ((state & 1<<i) || (lock & 1<<i)) {
-                    indicator += mod_sym[i];
+                if ((this.state & 1<<i) || (this.lock & 1<<i)) {
+                    this.indicator += mod_sym[i];
                 } else {
                     //indicator += "";
                 };
-                if (latch & 1<<i) {
-                    indicator += latch_sym + " ";
+                if (this.latch & 1<<i) {
+                    this.indicator += latch_sym + " ";
                 } else {
                     //indicator += "";
                 };
-                if (lock & 1<<i) {
-                    indicator += lock_sym + " ";
+                if (this.lock & 1<<i) {
+                    this.indicator += lock_sym + " ";
                 } else {
                     //indicator += "";
                 };
             }
-            indicator += " " + closing;
+            this.indicator += " " + closing;
 
-            label.text = indicator;
+            this.label.text = this.indicator;
 
-            prev_state = state;
-            prev_latch = latch;
-            prev_lock = lock;
+            this.prev_state = this.state;
+            this.prev_latch = this.latch;
+            this.prev_lock = this.lock;
         }
 
         console.debug(`${tag} _update() ... out`);
@@ -195,12 +205,12 @@ export default class KMS extends Extension {
         console.debug(`${tag} _a11y_mods_update() ... in`);
         //TODO: search what's the 1st parameter
         if (typeof latch_new !== 'undefined') {
-            latch = latch_new;
+            this.latch = latch_new;
         };
         if (typeof lock_new !== 'undefined') {
-            lock = lock_new;
+            this.lock = lock_new;
         };
-        console.debug(`${tag} latch: ${latch}, lock: ${lock}`);
+        console.debug(`${tag} latch: ${this.latch}, lock: ${this.lock}`);
         console.debug(`${tag} _a11y_mods_update() ... out`);
         //return true;
         return GLib.SOURCE_CONTINUE;

--- a/extension.js
+++ b/extension.js
@@ -28,6 +28,12 @@ import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const tag = "KMS-Ext:";
 
+// Print GNOME Shell and Clutter version to debug output.
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+import GIRepository from 'gi://GIRepository';
+console.debug(`${tag} Shell version: ${Config.PACKAGE_VERSION}`);
+console.debug(`${tag} Clutter API: ${GIRepository.Repository.get_default().get_version('Clutter')}`);  
+
 //TODO: convert into preferrence.
 // Mapping of modifier masks to the displayed symbol
 const MODIFIERS = [

--- a/extension.js
+++ b/extension.js
@@ -26,12 +26,9 @@ import GLib from 'gi://GLib';
 
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-//
-const dbg = false;
-
-//TODO: convert into preferrence.
 const tag = "KMS-Ext:";
 
+//TODO: convert into preferrence.
 // Mapping of modifier masks to the displayed symbol
 const MODIFIERS = [
     [Clutter.ModifierType.SHIFT_MASK, '⇧'],
@@ -43,7 +40,6 @@ const MODIFIERS = [
     [Clutter.ModifierType.MOD4_MASK, '⌘'],
     [Clutter.ModifierType.MOD5_MASK, '⎇'],
 ];
-
 const latch_sym = "'";
 const lock_sym = "◦";
 const icon = ""; //"⌨ ";
@@ -52,8 +48,7 @@ const closing = ""; //"_";
 
 
 // Gnome-shell extension interface
-// init, enable, disable
-
+// constructor, enable, disable
 export default class KMS extends Extension {
 
     seat = null;
@@ -164,7 +159,9 @@ export default class KMS extends Extension {
     //
     _update() {
         console.debug(`${tag} _update() ... in`);
-        //TODO: search for documentation about global
+        // `global` is provided by GNOME Shell and exposes Meta.Display APIs.
+        // See GNOME Shell architecture overview:
+        // https://gjs.guide/extensions/overview/architecture.html#shell
         //Note: modifiers state from get_pointer is the base not the effective
         // On latch active, it is on too. but on lock active, it is off
         // Not the case, using Gdk.Keymap.get_default().get_modifier_state() which
@@ -203,9 +200,9 @@ export default class KMS extends Extension {
     }
 
 
-    _a11y_mods_update(o, latch_new, lock_new) {
+    // The callback receives the Clutter.Seat that emitted the signal and the latched and locked modifier mask from stickykeys.
+    _a11y_mods_update(_seat, latch_new, lock_new) {
         console.debug(`${tag} _a11y_mods_update() ... in`);
-        //TODO: search what's the 1st parameter
         if (typeof latch_new !== 'undefined') {
             this.latch = latch_new;
         };

--- a/extension.js
+++ b/extension.js
@@ -19,14 +19,17 @@
 //
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
+import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
 
-//
+// This extension displays the currently active keyboard modifiers in the panel.
+// Modifier and wrapper symbols are configurable through GSettings and the provided preferences dialog.
+
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import GLib from 'gi://GLib';
 
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-const tag = "KMS-Ext:";
+const tag = 'KMS-Ext:';
 
 // Print GNOME Shell and Clutter version to debug output.
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
@@ -34,24 +37,18 @@ import GIRepository from 'gi://GIRepository';
 console.debug(`${tag} Shell version: ${Config.PACKAGE_VERSION}`);
 console.debug(`${tag} Clutter API: ${GIRepository.Repository.get_default().get_version('Clutter')}`);  
 
-//TODO: convert into preferrence.
-// Mapping of modifier masks to the displayed symbol
-const MODIFIERS = [
-    [Clutter.ModifierType.SHIFT_MASK, '⇧'],
-    [Clutter.ModifierType.LOCK_MASK, '⇬'],
-    [Clutter.ModifierType.CONTROL_MASK, '⋀'],
-    [Clutter.ModifierType.MOD1_MASK, '⌥'],
-    [Clutter.ModifierType.MOD2_MASK, '①'],
-    [Clutter.ModifierType.MOD3_MASK, '◆'],
-    [Clutter.ModifierType.MOD4_MASK, '⌘'],
-    [Clutter.ModifierType.MOD5_MASK, '⎇'],
-];
-const latch_sym = "'";
-const lock_sym = "◦";
-const icon = ""; //"⌨ ";
-const opening = ""; //"_";
-const closing = ""; //"_";
-
+// Mapping of logical modifier names to the Clutter.ModifierType constants used by GNOME Shell.
+// These values are stable across versions and avoid relying on internal bit ordering.
+const MODIFIER_ENUM = {
+    SHIFT:   Clutter.ModifierType.SHIFT_MASK,
+    LOCK:    Clutter.ModifierType.LOCK_MASK,
+    CONTROL: Clutter.ModifierType.CONTROL_MASK,
+    MOD1:    Clutter.ModifierType.MOD1_MASK,
+    MOD2:    Clutter.ModifierType.MOD2_MASK,
+    MOD3:    Clutter.ModifierType.MOD3_MASK,
+    MOD4:    Clutter.ModifierType.MOD4_MASK,
+    MOD5:    Clutter.ModifierType.MOD5_MASK,
+};
 
 // Gnome-shell extension interface
 // constructor, enable, disable
@@ -67,179 +64,205 @@ export default class KMS extends Extension {
     enable() {
         console.debug(`${tag} enable() ... in`);
 
-        this.state = 0;
-        this.prev_state = 0;
-        this.latch = 0;
-        this.prev_latch = null;
-        this.lock = 0;
-        this.prev_lock = null;
+        // Last retrieved modifier state and previous values for change tracking.
+        this._state = 0;
+        this._prev_state = null;
+        this._latch = 0;
+        this._prev_latch = null;
+        this._lock = 0;
+        this._prev_lock = null;
 
-        this.indicator = null;
+        // Symbols read from settings describing each modifier and extra wrapper characters.
+        this._symModifiers = [];
+        this._symLatch = '';
+        this._symLock = '';
+        this._symIcon = '';  // prefix symbol
+        this._symOpening = '';
+        this._symClosing = '';
 
-        this.settings = this.getSettings();
+        // GSettings object for retrieving user preferences.
+        this._settings = this.getSettings();
         this._loadSettings();
-        this.settingsChangedId = this.settings.connect('changed', () => {
+        // Reload symbols whenever preferences change.
+        this._settingsChangedId = this._settings.connect('changed', () => {
             this._loadSettings();
             // Force indicator refresh on next _update (every 200ms).
-            this.prev_state = null;
+            this._prev_state = null;
         });
 
-        // Create UI elements
-        this.button = new St.Bin({ style_class: 'panel-button',
+
+        // Create the indicator displayed in the top panel.
+        this._indicator = new St.Bin({ style_class: 'panel-button',
             reactive: false,
             can_focus: false,
             x_expand: true,
             y_expand: false,
             track_hover: false });
-        this.label = new St.Label({ style_class: "state-label", text: "" });
-        this.button.set_child(this.label);
-        Main.panel._rightBox.insert_child_at_index(this.button, 0);
+        this._indicatorText = '';
+        this._label = new St.Label({ style_class: 'state-label', text: this._indicatorText });
+        this._indicator.set_child(this._label);
+        Main.panel._rightBox.insert_child_at_index(this._indicator, 0);
 
         //console.debug(`${tag} Running Wayland: ` + Meta.is_wayland_compositor());
 
         try {
-            this.seat = Clutter.get_default_backend().get_default_seat();
+            // Clutter 1.24+ exposes the default seat via the backend object.
+            this._seat = Clutter.get_default_backend().get_default_seat();
         } catch (e) {
-            this.seat = Clutter.DeviceManager.get_default();
-        };
+            // Older versions fall back to DeviceManager.
+            this._seat = Clutter.DeviceManager.get_default();
+        }
 
-        if (this.seat) {
-            this.mods_update_id = this.seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update.bind(this));
-        };
+        if (this._seat) {
+            // Listen for changes from the "sticky keys" accessibility feature.
+            this._mods_update_id = this._seat.connect('kbd-a11y-mods-state-changed', this._a11y_mods_update.bind(this));
+        }
 
-        this.timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update.bind(this));
+        // Periodically refresh the indicator (200ms).
+        this._timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update.bind(this));
 
         console.debug(`${tag} enable() ... out`);
     }
 
-
+    // Tear down everything created in enable().
     disable() {
         console.debug(`${tag} disable() ... in`);
 
-        if (this.timeout_id) {
-            GLib.source_remove(this.timeout_id);
-            this.timeout_id = null;
+        if (this._timeout_id) {
+            GLib.source_remove(this._timeout_id);
+            this._timeout_id = null;
         }
 
-        if (this.seat) {
-            if (this.mods_update_id) {
-                this.seat.disconnect(this.mods_update_id);
-                this.mods_update_id = null;
+        if (this._seat) {
+            if (this._mods_update_id) {
+                this._seat.disconnect(this._mods_update_id);
+                this._mods_update_id = null;
             }
-            this.seat = null;
+            this._seat = null;
         };
 
-        if (this.button) {
-            Main.panel._rightBox.remove_child(this.button);
-            this.button.destroy_all_children();
-            this.button.destroy();
-            this.button = null;
-            this.label = null;
+        if (this._indicator) {
+            Main.panel._rightBox.remove_child(this._indicator);
+            this._indicator.destroy_all_children();
+            this._indicator.destroy();
+            this._indicator = null;
+            this._label = null;
+            this._indicatorText = '';
         }
 
-        if (this.settings) {
-            if (this.settingsChangedId) {
-                this.settings.disconnect(this.settingsChangedId);
-                this.settingsChangedId = null;
+        if (this._settings) {
+            if (this._settingsChangedId) {
+                this._settings.disconnect(this._settingsChangedId);
+                this._settingsChangedId = null;
             }
-            this.settings = null;
+            this._settings = null;
         }
+        this._symModifiers = [];
+        this._symLatch = '';
+        this._symLock = '';
+        this._symIcon = '';
+        this._symOpening = '';
+        this._symClosing = '';
 
-        this.indicator = null;
 
-        this.state = 0;
-        this.prev_state = 0;
-        this.latch = 0;
-        this.prev_latch = null;
-        this.lock = 0;
-        this.prev_lock = null;
+        this._state = 0;
+        this._prev_state = null;
+        this._latch = 0;
+        this._prev_latch = null;
+        this._lock = 0;
+        this._prev_lock = null;
 
         console.debug(`${tag} disable() ... out`);
     }
 
+    // Read all user-configurable symbols from GSettings.
     _loadSettings() {
         console.debug(`${tag} _loadSettings() ... in`);
 
-        if (!this.settings) {
-            console.warning(`${tag} this.settings is null`);
+        if (!this._settings) {
+            console.warn(`${tag} this._settings is null`);
             return;
         }
 
-        MODIFIERS = [
-            [MODIFIER_ENUM.SHIFT, this.settings.get_string('shift-symbol')],
-            [MODIFIER_ENUM.LOCK, this.settings.get_string('caps-symbol')],
-            [MODIFIER_ENUM.CONTROL, this.settings.get_string('control-symbol')],
-            [MODIFIER_ENUM.MOD1, this.settings.get_string('mod1-symbol')],
-            [MODIFIER_ENUM.MOD2, this.settings.get_string('mod2-symbol')],
-            [MODIFIER_ENUM.MOD3, this.settings.get_string('mod3-symbol')],
-            [MODIFIER_ENUM.MOD4, this.settings.get_string('mod4-symbol')],
-            [MODIFIER_ENUM.MOD5, this.settings.get_string('mod5-symbol')],
+        this._symModifiers = [
+            [MODIFIER_ENUM.SHIFT, this._settings.get_string('shift-symbol')],
+            [MODIFIER_ENUM.LOCK, this._settings.get_string('caps-symbol')],
+            [MODIFIER_ENUM.CONTROL, this._settings.get_string('control-symbol')],
+            [MODIFIER_ENUM.MOD1, this._settings.get_string('alt-symbol')],
+            [MODIFIER_ENUM.MOD2, this._settings.get_string('num-symbol')],
+            [MODIFIER_ENUM.MOD3, this._settings.get_string('scroll-symbol')],
+            [MODIFIER_ENUM.MOD4, this._settings.get_string('super-symbol')],
+            [MODIFIER_ENUM.MOD5, this._settings.get_string('altgr-symbol')],
         ];
-        latch_sym = this.settings.get_string('latch-symbol');
-        lock_sym = this.settings.get_string('lock-symbol');
-        icon = this.settings.get_string('icon');
-        opening = this.settings.get_string('opening');
-        closing = this.settings.get_string('closing');
+        console.debug(`${tag} modifiers: ${this._symModifiers.map(v => v[1])}`);
+        this._symLatch = this._settings.get_string('latch-symbol');
+        this._symLock = this._settings.get_string('lock-symbol');
+        console.debug(`${tag} accessibility: ${this._symLatch},${this._symLock}`);
+        this._symIcon = this._settings.get_string('icon-symbol');
+        this._symOpening = this._settings.get_string('opening-symbol');
+        this._symClosing = this._settings.get_string('closing-symbol');
+        console.debug(`${tag} wrappers: ${this._symIcon},${this._symOpening},${this._symClosing}`);
 
         console.debug(`${tag} _loadSettings() ... out`);
     }
 
-    //
+    // Called periodically to refresh the label with the current modifier state.
     _update() {
         console.debug(`${tag} _update() ... in`);
         // `global` is provided by GNOME Shell and exposes Meta.Display APIs.
         // See GNOME Shell architecture overview:
         // https://gjs.guide/extensions/overview/architecture.html#shell
-        //Note: modifiers state from get_pointer is the base not the effective
+        // Note: modifiers state from get_pointer is the base not the effective
         // On latch active, it is on too. but on lock active, it is off
         // Not the case, using Gdk.Keymap.get_default().get_modifier_state() which
         // is the effective
 
+        // Current pointer position and modifier mask.
         const [x, y, m] = global.get_pointer();
 
         if (typeof m !== 'undefined') {
-            this.state = m;
+            this._state = m;
         };
 
-        if ((this.state != this.prev_state) || this.latch != this.prev_latch || this.lock != this.prev_lock) {
-            console.debug(`${tag} State changed... ${this.prev_state}, ${this.state}`);
-            this.indicator = icon + opening + " ";
+        if (this._state != this._prev_state || this._latch != this._prev_latch || this._lock != this._prev_lock) {
+            console.debug(`${tag} State ${this._prev_state}->${this._state}, latch ${this._prev_latch}->${this._latch} or lock ${this._prev_lock}->${this._lock} changed`);
+            this._indicatorText = this._symIcon + this._symOpening;
             // Iterate using the predefined modifier masks
-            for (const [mask, sym] of MODIFIERS) {
-                if ((this.state & mask) || (this.lock & mask))
-                    this.indicator += sym;
-                if (this.latch & mask)
-                    this.indicator += latch_sym + ' ';
-                if (this.lock & mask)
-                    this.indicator += lock_sym + ' ';
+            for (const [mask, sym] of this._symModifiers) {
+                // Display the symbol whenever the modifier is active, latched or locked.
+                if ((this._state & mask) || (this._latch & mask) || (this._lock & mask))
+                    this._indicatorText += sym;
+                // Append latch/lock indicators if necessary.
+                if (this._latch & mask)
+                    this._indicatorText += this._symLatch;
+                if (this._lock & mask)
+                    this._indicatorText += this._symLock;
             }
-            this.indicator += " " + closing;
+            this._indicatorText += this._symClosing;
 
-            this.label.text = this.indicator;
+            this._label.text = this._indicatorText;
 
-            this.prev_state = this.state;
-            this.prev_latch = this.latch;
-            this.prev_lock = this.lock;
+            this._prev_state = this._state;
+            this._prev_latch = this._latch;
+            this._prev_lock = this._lock;
         }
 
         console.debug(`${tag} _update() ... out`);
-        //return true;
         return GLib.SOURCE_CONTINUE;
     }
 
-
-    // The callback receives the Clutter.Seat that emitted the signal and the latched and locked modifier mask from stickykeys.
+    // Callback for the 'kbd-a11y-mods-state-changed' signal emitted by Clutter.Seat.
+    // Updates stored latch and lock states used by the indicator.
     _a11y_mods_update(_seat, latch_new, lock_new) {
         console.debug(`${tag} _a11y_mods_update() ... in`);
         if (typeof latch_new !== 'undefined') {
-            this.latch = latch_new;
+            this._latch = latch_new;
         };
         if (typeof lock_new !== 'undefined') {
-            this.lock = lock_new;
+            this._lock = lock_new;
         };
-        console.debug(`${tag} latch: ${this.latch}, lock: ${this.lock}`);
+        console.debug(`${tag} latch: ${this._latch}, lock: ${this._lock}`);
         console.debug(`${tag} _a11y_mods_update() ... out`);
-        //return true;
         return GLib.SOURCE_CONTINUE;
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,6 @@
 	"name": "Keyboard Modifiers Status",
 	"description": "Shows keyboard modifiers status. It's useful when sticky keys are active.",
 	"original-author": "sneetsher@localhost",
-	"url": "https://github.com/sneetsher/Keyboard-Modifiers-Status"
+        "url": "https://github.com/sneetsher/Keyboard-Modifiers-Status",
+        "settings-schema": "org.gnome.shell.extensions.keyboard-modifiers-status"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,363 @@
+import Gtk from 'gi://Gtk';
+import Adw from 'gi://Adw';
+import GLib from 'gi://GLib';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+// Preferences dialog for the Keyboard Modifiers Status extension.
+// It exposes customizable symbols grouped into modifier, accessibility and wrapper categories.
+// Each category has some presets and Customized symbols can be saved into "Saved" preset.
+
+const tag = 'KMS-Ext-Prefs:';
+
+export default class Prefs extends ExtensionPreferences {
+
+	fillPreferencesWindow(window) {
+		console.debug(`${tag} fillPreferencesWindow() ... in`);
+
+		this._settings = this.getSettings();
+		this._schema = this._settings.settings_schema;
+		this._window = window;
+
+		// Keys grouped by their meaning in the settings schema.
+		const modifiersKeys = ['shift-symbol', 'caps-symbol', 'control-symbol', 'alt-symbol', 'num-symbol', 'scroll-symbol', 'super-symbol', 'altgr-symbol'];
+		const accessibilityKeys = ['latch-symbol', 'lock-symbol'];
+		const wrapperKeys = ['icon-symbol', 'opening-symbol', 'closing-symbol'];
+
+		// Cache current values from GSettings and previously saved preset.
+		this._currentSymbols = this._getSchemaModifierSymbols([].concat(modifiersKeys, accessibilityKeys, wrapperKeys));
+		this._savedSymbols = this._settings.get_value('saved-symbols').deep_unpack();
+		console.debug(`${tag} this._currentSymbols: ${JSON.stringify(this._currentSymbols)}`);
+		console.debug(`${tag} this._savedSymbols: ${JSON.stringify(this._savedSymbols)}`);
+
+		// Keep references to entry widgets for each key to sync changes.
+		this._groupEntries = {};
+		this._page = new Adw.PreferencesPage();
+
+		// Add groups with presets into the page.
+		this._addGroup(
+			_('Modifier symbols' ),
+			_('Modifier symbols show which modifier keys are currently pressed.'),
+			modifiersKeys,
+			new Map([
+				[_('Mac'), this._getSchemaDefaults(modifiersKeys)], // ['⇧', '⇬', '⋀', '⌥', '①', '◆', '⌘', '⎇']
+				[_('PC'),  ['⇧', '⇪', '⌃', '⎇', '⇭', '⇳', '❖', '⎈']],
+			])
+		);
+		this._addGroup(
+			_('Accesibility symbols' ),
+			_('Accessibility symbols indicate latched or locked key states for assistive input.'),
+			accessibilityKeys,
+			new Map([
+				[_('Degrees'), this._getSchemaDefaults(accessibilityKeys)], // ['\'', '°']
+				[_('DotPair'),  ['.', ':']],
+			])
+		);
+		this._addGroup(
+			_('Wrapper symbols' ),
+			_('Wrapper symbols visually enclose active modifiers to enhance clarity.'),
+			wrapperKeys,
+			new Map([
+				[_('Keyboard'), ['⌨', '', '']],
+				[_('Brackets'),  ['', '[', ']']],
+			])
+		);
+
+		window.add(this._page);
+		window.show();
+
+		console.debug(`${tag} fillPreferencesWindow() ... out`);
+	}
+
+	// Helper to build a preference group with a presets drop-down and entry fields.
+	_addGroup(title, description, keys, presets) {
+		console.debug(`${tag} _addGroup() ... in`);
+		const group = new Adw.PreferencesGroup({title: title, description: description});
+
+		// Create presets UI elements.
+		const headerBox = new Gtk.Box({spacing: 6});
+		// Allows to choose from presets, including the Saved preset.
+		const presetsDropDown = Gtk.DropDown.new_from_strings([_('Custom')].concat(Array.from(presets.keys()), [_('Saved')]));
+		presetsDropDown.valign = Gtk.Align.CENTER;
+		// Allows persisting the current custom symbols.
+		const saveButton = Gtk.Button.new_with_label(_('Save'));
+		saveButton.add_css_class('suggested-action');
+		saveButton.valign      = Gtk.Align.CENTER;
+		saveButton.visible = false;
+		headerBox.append(new Gtk.Label({label: _('Presets')}));
+		headerBox.append(presetsDropDown);
+		headerBox.append(saveButton);
+		group.set_header_suffix(headerBox);
+
+		const savedIndex = presets.size + 1;
+		// Helper function to refresh the visibility of the Save button.
+		const refreshSaveButton = () => {
+			console.debug(`${tag} refreshSaveButton: selected: ${presetsDropDown.selected}, differ: ${this._currentDifferSaved(keys)}`);
+			saveButton.visible = presetsDropDown.selected === 0 && this._currentDifferSaved(keys);
+		};
+
+		// Helper function to update the presets dropdown, according to currently used symbols.
+		const updatePresetsBox = (dropdownNotifyId) => {
+			console.debug(`${tag} _addGroup: updatePresetsBox(${dropdownNotifyId})`);
+			let foundIdx = 0;
+			// Check if current symbols are the same as Saved symbols.
+			if (!this._currentDifferSaved(keys)) {
+				foundIdx = savedIndex;
+			} else {
+				// Check if current symbols are the same as any of the hardcoded presets symbols.
+				foundIdx = Array.from(presets).findIndex(([_title, preset]) => keys.every((k, i) => this._currentSymbols[k] == preset[i])) + 1;
+			}
+			if (presetsDropDown.selected != foundIdx) {
+				// Dropdown selected item has to change, but first block signals from triggering the update of the dropdown.
+				presetsDropDown.block_signal_handler(dropdownNotifyId);
+				console.debug(`${tag} updatePresetsBox: set dropdown selected: ${foundIdx}`);
+				presetsDropDown.selected = foundIdx;
+				// Wait until idle, to not unblock too early. When unblocking without wait, the dropdown update is sometimes triggered.
+				GLib.idle_add(null, () => {
+					presetsDropDown.unblock_signal_handler(dropdownNotifyId);
+					return GLib.SOURCE_REMOVE;
+				});
+			}
+			refreshSaveButton();
+		};
+
+		// If dropdown is changed, apply the selected preset.
+		const dropdownNotifyId = presetsDropDown.connect('notify::selected', () => {
+			const idx = presetsDropDown.selected;
+			console.debug(`${tag} presetsDropDown.notify::selected saveButton.visible: ${saveButton.visible}, selected: ${idx}`);
+			if (idx === 0) {
+				updatePresetsBox(dropdownNotifyId);
+				return;
+			}
+			// Helper function to apply the selected preset.
+			const applyPreset = () => {
+				const values = idx === savedIndex
+					? keys.map(k => this._savedSymbols[k] ?? '')
+					: Array.from(presets.values())[idx - 1];
+				console.debug(`${tag} presetsDropDown.notify::selected: applyPreset ${idx}: ${values}`);
+				// Change each text entry and current settings according to selected preset.
+				keys.forEach((k, i) => {
+					const val = values[i];
+					if (this._groupEntries[k] && this._currentSymbols[k] !== val) {
+						this._currentSymbols[k] = val;
+						const { entry, changedId } = this._groupEntries[k];
+						if (entry) {
+							// Block entry update signal before changing, to not trigger update.
+							entry.block_signal_handler(changedId);
+							console.debug(`${tag} presetsDropDown.notify::selected: applyPreset: change entry text: ${entry.text} -> ${val}`);
+							entry.text = val;
+							// Wait before unblocking, to not unblock too early and trigger update.
+							GLib.idle_add(null, () => {
+								entry.unblock_signal_handler(changedId);
+								return GLib.SOURCE_REMOVE;
+							});
+						}
+						console.debug(`${tag} presetsDropDown.notify::selected: applyPreset: set ${k} to ${val}`);
+						// Save to settings.
+						this._settings.set_string(k, val);
+					}
+				});
+				refreshSaveButton();
+			};
+			// A visible save button indicates unsaved changes when switching from custom preset in dropdown.
+			if (saveButton.visible) {
+				this._showSwitchDialog(title, keys, presetsDropDown, dropdownNotifyId, applyPreset);
+				return;
+			}
+			applyPreset();
+		});
+
+		// Save symbols to Saved preset when save button is clicked.
+		saveButton.connect('clicked', () => {
+			console.debug(`${tag} saveButton:clicked`);
+			keys.forEach(k => {
+				this._savedSymbols[k] = this._currentSymbols[k];
+			});
+			console.debug(`${tag} saveButton:clicked: set saved symbols to: ${JSON.stringify(this._savedSymbols)}`);
+			this._settings.set_value('saved-symbols', new GLib.Variant('a{ss}', this._savedSymbols));
+			updatePresetsBox(dropdownNotifyId);
+		});
+
+		// When saved symbols are changed outside from these preferences, update the UI elements.
+		this._settings.connect('changed::saved-symbols', () => {
+			console.debug(`${tag} settings:changed::saved-symbols`);
+			const newSavedSymbols = this._settings.get_value('saved-symbols').deep_unpack();
+			const equal = this._symbolsObjectsEqual(this._savedSymbols, newSavedSymbols);
+			console.debug(`${tag} settings:changed::saved-symbols: new ${JSON.stringify(newSavedSymbols)}, equal:${equal}`);
+			if (!equal) {
+				updatePresetsBox(dropdownNotifyId);
+			}
+		});
+
+		// Update the newly created dropbox and save button accordingly to current set symbols.
+		updatePresetsBox(dropdownNotifyId);
+
+		// Create a row with label and text entry for each symbol settings.
+		keys.forEach(key => {
+			const schemaKey = this._schema.get_key(key);
+			if (!schemaKey) {
+				console.warn(`${tag} schema doesn't contain modifier key: ${key}`);
+				return;
+			}
+			// Check for duplicate keys.
+			if (this._groupEntries[key]) {
+				console.warn(`${tag} addGroup: duplicate key: ${key}`);
+				return;
+			}
+			// Create the row with text entry.
+			const entry = new Gtk.Entry({text: _(this._currentSymbols[key])});
+			const row = new Adw.ActionRow({title: _(schemaKey.get_summary())});
+			row.add_suffix(entry);
+			row.activatable_widget = entry;
+			group.add(row);
+			console.debug(`${tag} _addGroup: add entry ${key}: ${entry.text}`);
+			// If entry is changed, change the setting and update presets box.
+			const entry_changed_id = entry.connect('changed', () => {
+				console.debug(`${tag} _addGroup: entry::changed ${key}: ${this._currentSymbols[key]} -> ${entry.text})`);
+				if (this._currentSymbols[key] !== entry.text) {
+					this._currentSymbols[key] = entry.text;
+					console.debug(`${tag} _addGroup: entry::changed ${key}: set setings key: ${entry.text}`);
+					this._settings.set_string(key, entry.text);
+					updatePresetsBox(dropdownNotifyId);
+				}
+			});
+			this._groupEntries[key] = {
+				entry: entry,
+				changedId: entry_changed_id
+			};
+
+			// Handle the settings changed outside of this presets and populate UI elements if needed..
+			this._settings.connect(`changed::${key}`, () => {
+				console.debug(`${tag} _addGroup: setting::changed::${key}() ... in`);
+				const val = this._settings.get_string(key);
+				if (this._currentSymbols[key] !== val) {
+					console.debug(`${tag} _addGroup: setting::changed::${key} : ${this._currentSymbols[key]} -> ${val})`);
+					this._currentSymbols[key] = val;
+					// Block entry update signal before changing, to not trigger update.
+					entry.block_signal_handler(entry_changed_id);
+					console.debug(`${tag} _addGroup: entry::changed ${key}: entry textset ${val}`);
+					entry.text = val;
+					// Wait before unblocking, to not unblock too early and trigger update.
+					GLib.idle_add(null, () => {
+						entry.unblock_signal_handler(entry_changed_id);
+						return GLib.SOURCE_REMOVE;
+					});
+					updatePresetsBox(dropdownNotifyId);
+				}
+				console.debug(`${tag} _addGroup: setting::changed::${key}() ... out`);
+			});
+		});
+
+		this._page.add(group);
+		console.debug(`${tag} _addGroup() ... out`);
+	}
+
+	// Create and show an dialog with custom and saved symbols overview and ask if cancel, save & switch or switch without saving.
+	_showSwitchDialog(title, keys, presetsDropDown, dropdownNotifyId, applyPreset) {
+		console.debug(`${tag} _showSwitchDialog(title: ${title}, ...)`);
+
+		const dialog = new Adw.MessageDialog({
+			transient_for: this._window,
+			modal: true,
+			heading: _(`Unsaved custom symbols`),
+			body: _(`Switching presets to`) + `"${presetsDropDown.get_selected_item().get_string()}" ` + _(`will discard your custom symbols. Do you want to save before switching?`),
+		});
+
+		// Show table of differing values between current custom symbols and the last saved preset.
+		const grid = new Gtk.Grid({
+			column_spacing: 12,
+			row_spacing: 12,
+			halign: Gtk.Align.CENTER,
+			hexpand: true,
+			margin_top: 12,
+			margin_bottom: 12,
+			margin_start: 12,
+			margin_end: 12,
+		});
+		// Fill header of the table.
+		const headers = [title, _('Custom'), _('Saved')];
+		headers.forEach((h, i) => {
+			const label = new Gtk.Label({
+				label: h,
+				halign: Gtk.Align.CENTER,
+				hexpand: true,
+				width_chars: Math.max(6, h.length),
+			});
+			label.add_css_class('heading');
+			grid.attach(label, i, 0, 1, 1);
+		});
+		// Fill rows of the table.
+		let row = 1;
+		keys.forEach(k => {
+			const current = this._currentSymbols[k] ?? '';
+			const saved = this._savedSymbols[k] ?? '';
+			if (current !== saved) {
+				const cells = [_(this._schema.get_key(k).get_summary()), current, saved];
+				cells.forEach((v, i) => {
+					const label = new Gtk.Label({
+						label: v,
+						halign: Gtk.Align.CENTER,
+						hexpand: true,
+					});
+					if (i === 0)
+						label.add_css_class('heading');
+					grid.attach(label, i, row, 1, 1);
+				});
+				row++;
+			}
+		});
+		if (row > 1)
+			dialog.set_extra_child(grid);
+
+		// Add response buttons.
+		dialog.add_response('cancel', _('Cancel'));
+		dialog.add_response('save', _('Save'));
+		dialog.add_response('switch', _('Switch'));
+		dialog.set_response_appearance('save', Adw.ResponseAppearance.SUGGESTED);
+		dialog.set_response_appearance('switch', Adw.ResponseAppearance.DESTRUCTIVE);
+		dialog.set_default_response('cancel');
+		dialog.set_close_response('cancel');
+		dialog.connect('response', (_d, resp) => {
+			console.debug(`${tag} _showSwitchDialog: dialog:response: ${resp}`);
+			if (resp === 'cancel') {
+				// Cancel was clicked, return dropdown to Custom preset, but block signal first to not trigger the update again.
+				presetsDropDown.block_signal_handler(dropdownNotifyId);
+				presetsDropDown.selected = 0; // Custom preset.
+				// Wait before unblocking to not unblock too early and triggering the update.
+				GLib.idle_add(null, () => {
+					presetsDropDown.unblock_signal_handler(dropdownNotifyId);
+					return GLib.SOURCE_REMOVE;
+				});
+			} else {
+				// Save or Switch was clicked. Switch anyways, but if save was clicked, save first.
+				if (resp === 'save') {
+					keys.forEach(k => {
+						this._savedSymbols[k] = this._currentSymbols[k];
+					});
+					this._settings.set_value('saved-symbols', new GLib.Variant('a{ss}', this._savedSymbols));
+				}
+				applyPreset();
+			}
+			dialog.destroy();
+		});
+		dialog.show();
+	}
+
+	// Convenience helpers for manipulating GSettings values.
+	_getSchemaDefaults(keys) {
+		return keys.map(k => this._settings.get_default_value(k).deep_unpack());
+	}
+	_getSchemaModifierSymbols(keys) {
+		return Object.fromEntries(keys.map(k => [k, this._settings.get_string(k)]));
+	}
+	_symbolsObjectsEqual(a, b) {
+		return Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => (b[k] ?? '') === (a[k] ?? ''));
+	}
+	_currentDifferSaved(keys) {
+		// Returns true when the current values diverge from the last saved preset.
+		return keys.some(k => this._currentSymbols[k] !== (this._savedSymbols[k] ?? ''));
+	}
+}
+
+export function init() {
+	return new Prefs();
+}

--- a/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.keyboard-modifiers-status" path="/org/gnome/shell/extensions/keyboard-modifiers-status/">
+		<key name="shift-symbol" type="s">
+			<default>'⇧'</default>
+			<summary>Shift</summary>
+			<description>Symbol displayed when the Shift modifier is active.</description>
+		</key>
+		<key name="caps-symbol" type="s">
+			<default>'⇬'</default>
+			<summary>Caps Lock</summary>
+			<description>Symbol displayed when the Caps Lock modifier is active.</description>
+		</key>
+		<key name="control-symbol" type="s">
+			<default>'⋀'</default>
+			<summary>Control</summary>
+			<description>Symbol displayed when the Control modifier is active.</description>
+		</key>
+		<key name="alt-symbol" type="s">
+			<default>'⌥'</default>
+			<summary>Alt</summary>
+			<description>Symbol displayed when the Alt modifier is active.</description>
+		</key>
+		<key name="num-symbol" type="s">
+			<default>'①'</default>
+			<summary>Num Lock</summary>
+			<description>Symbol displayed when the Num Lock modifier is active.</description>
+		</key>
+		<key name="scroll-symbol" type="s">
+			<default>'◆'</default>
+			<summary>Scroll Lock</summary>
+			<description>Symbol displayed when the Scroll Lock modifier is active.</description>
+		</key>
+		<key name="super-symbol" type="s">
+			<default>'⌘'</default>
+			<summary>Super</summary>
+			<description>Symbol displayed when the Super modifier is active.</description>
+		</key>
+		<key name="altgr-symbol" type="s">
+			<default>'⎇'</default>
+			<summary>AltGr</summary>
+			<description>Symbol displayed when the AltGr modifier is active.</description>
+		</key>
+		<key name="latch-symbol" type="s">
+			<default>'\''</default>
+			<summary>Latch</summary>
+			<description>Symbol displayed when a modifier is latched.</description>
+		</key>
+		<key name="lock-symbol" type="s">
+			<default>'◦'</default>
+			<summary>Lock</summary>
+			<description>Symbol displayed when a modifier is locked.</description>
+		</key>
+		<key name="icon-symbol" type="s">
+			<default>''</default>
+			<summary>Icon</summary>
+			<description>Optional string shown before the opening of modifiers list.</description>
+		</key>
+		<key name="opening-symbol" type="s">
+			<default>''</default>
+			<summary>Opening</summary>
+			<description>String placed before the modifiers state display.</description>
+		</key>
+		<key name="closing-symbol" type="s">
+			<default>''</default>
+			<summary>Closing</summary>
+			<description>String placed after the modifiers state display.</description>
+		</key>
+		<key name="saved-symbols" type="a{ss}">
+			<default>{}</default>
+			<summary>Saved custom symbols</summary>
+			<description>Symbol values stored when using the Save preset.</description>
+		</key>
+	</schema>
+</schemalist>

--- a/scripts/nested-gnome-wayland.sh
+++ b/scripts/nested-gnome-wayland.sh
@@ -7,4 +7,4 @@ export SHELL_DEBUG=all
 dbus-run-session -- \
     gnome-shell --nested \
                 --wayland \
-    2>&1 | grep KMS
+    2>&1 | grep -P KMS\|CRITICAL


### PR DESCRIPTION
Hi, I've been using this extension for long time and it is very helpful for me. Thanks.

I've used another set of modifier symbols and after every update I had to edit the code again and set my symbols again. So I made these updates to be able configure the symbols in preferences and not loose them after update.

I also tackled some TODOs I found in the code. These are the first 5 commits, one TODO for commit  and every commit is described.

The last commit is bigger and most of it is the `prefs.js` file.

-------

This is how settings look like:
  ![image](https://github.com/user-attachments/assets/bac1f74f-dbac-405d-b82a-db92e839c1f3)

I split the symbols into logic groups added preset for each groups, with ability to save the custom symbols to a Saved preset:
  ![image](https://github.com/user-attachments/assets/68c5e9d0-1b66-4d5b-81a3-434d7b830d7c)

To not accidentally loose unsaved custom symbols when switching preset a dialog was added:
  ![image](https://github.com/user-attachments/assets/35f8b003-a5ee-41d6-8929-f757ca36510b)

Note: You can write multiple characters into the symbols entry, including a newline (copied/pasted from editing app). This way I customized it for my vertical taskbar setup:
  ![image](https://github.com/user-attachments/assets/98cf6765-476b-4785-a681-7407bb7f72e9)

Note2: In `extension.js` I removed the " " (space) after latch, lock, opening and before closing symbols. You can add the spaces in settings if missing.
